### PR TITLE
Iss644 - Dictionary configuration macros

### DIFF
--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -101,10 +101,10 @@ macro(setup_library)
                         "${multiValueArgs}" ${ARGN})
 
   # Build the library name and source path
-  set(library_name "${setup_library_name}")
-  set(src_path "${PROJECT_SOURCE_DIR}/src/${setup_library_name}")
-  set(include_path "include/${setup_library_name}")
-  if(setup_library_module)
+  set(library_name "${setup_library_module}")
+  set(src_path "${PROJECT_SOURCE_DIR}/src/${setup_library_module}")
+  set(include_path "include/${setup_library_module}")
+  if(setup_library_name)
     set(library_name "${setup_library_module}_${setup_library_name}")
     set(src_path
         "${PROJECT_SOURCE_DIR}/src/${setup_library_module}/${setup_library_name}"
@@ -137,11 +137,12 @@ macro(setup_library)
   endif()
 
   # Setup the targets to link against
+  message(STATUS "Library name: ${library_name}")
   target_link_libraries(${library_name} PUBLIC ${setup_library_dependencies})
 
   # Define an alias. This is used to create the imported target.
-  set(alias "${setup_library_name}::${setup_library_name}")
-  if(setup_library_module)
+  set(alias "${setup_library_module}::${setup_library_module}")
+  if(setup_library_name)
     set(alias "${setup_library_module}::${setup_library_name}")
   endif()
   add_library(${alias} ALIAS ${library_name})

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -114,15 +114,15 @@ macro(setup_library)
     #NOT SURE IF NEEDED
     #   do I need to remove the source files that were compiled into the 
     #   event bus dictionary? Or is it okay for them to be compiled twice?
-#    set(link_against_dictionary "NO")
-#    foreach(src ${SRC_FILES})
-#        list(FIND event_sources ${src} index)
-#        if(${index} GREATER 0)
-#            #found ==> is an event passenger
-#            list(REMOVE_ITEM SRC_FILES ${src})
-#            set(link_against_dictionary "YES")
-#        endif()
-#    endforeach()
+    set(link_against_dictionary "NO")
+    foreach(src ${SRC_FILES})
+        list(FIND event_sources ${src} index)
+        if(${index} GREATER 0)
+            #found ==> is an event passenger
+            list(REMOVE_ITEM SRC_FILES ${src})
+            set(link_against_dictionary "YES")
+        endif()
+    endforeach()
 
     # Create the SimCore shared library
     add_library(${setup_library_name} SHARED ${SRC_FILES})
@@ -131,9 +131,9 @@ macro(setup_library)
     target_include_directories(${setup_library_name} PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
     # Setup the targets to link against 
-#    if(${link_against_dictionary} STREQUAL "YES")
-#        list(APPEND setup_library_dependencies "DARK::Event")
-#    endif()
+    if(${link_against_dictionary} STREQUAL "YES")
+        list(APPEND setup_library_dependencies "DARK::Event")
+    endif()
     target_link_libraries(${setup_library_name} PUBLIC ${setup_library_dependencies})
 
     # Define an alias. This is used to create the imported target.
@@ -261,9 +261,7 @@ macro(setup_dictionary)
             "#pragma link C++ class ${class}+;\n"
             )
     endforeach()
-    file(APPEND ${event_link_def_file}
-        "\n#endif"
-        )
+    file(APPEND ${event_link_def_file} "\n#endif")
 
     message("Wrote ${event_link_def_file}")
     
@@ -333,6 +331,7 @@ macro(setup_dictionary)
     # Create the Event shared library
     list(APPEND event_sources "EventDict.cxx")
     message("Event Sources:'${event_sources}'")
+
     add_library(Event SHARED ${event_sources})
 
     # Setup the include directories 

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -4,28 +4,28 @@ include(CMakeParseArguments)
 
 # Define some colors. These are used to colorize CMake's user output
 if (NOT WIN32)
-    string(ASCII 27 esc)
-    set(color_reset "${esc}[m")
-    set(bold_yellow "${esc}[1;33m")
-    set(green       "${esc}[32m")
-    set(bold_red    "${esc}[1;31m")
+  string(ASCII 27 esc)
+  set(color_reset "${esc}[m")
+  set(bold_yellow "${esc}[1;33m")
+  set(green       "${esc}[32m")
+  set(bold_red    "${esc}[1;31m")
 endif()
 
 # Override messages and add color
 function(message)
-    list(GET ARGV 0 message_type)
-    if(message_type STREQUAL FATAL_ERROR OR message_type STREQUAL SEND_ERROR)
-        list(REMOVE_AT ARGV 0)
-        _message("${bold_red}[ ERROR ]: ${ARGV}${color_reset}")
-    elseif(message_type STREQUAL WARNING OR message_type STREQUAL AUTHOR_WARNING)
-        list(REMOVE_AT ARGV 0)
-        _message("${bold_yellow}[ WARNING ]: ${ARGV}${color_reset}")
-    elseif(message_type STREQUAL STATUS)
-        list(REMOVE_AT ARGV 0)
-        _message("${green}[ INFO ]: ${ARGV}${color_reset}")
-    else()
-        _message("${green} ${ARGV} ${color_reset}")
-    endif()
+  list(GET ARGV 0 message_type)
+  if(message_type STREQUAL FATAL_ERROR OR message_type STREQUAL SEND_ERROR)
+    list(REMOVE_AT ARGV 0)
+    _message("${bold_red}[ ERROR ]: ${ARGV}${color_reset}")
+  elseif(message_type STREQUAL WARNING OR message_type STREQUAL AUTHOR_WARNING)
+    list(REMOVE_AT ARGV 0)
+    _message("${bold_yellow}[ WARNING ]: ${ARGV}${color_reset}")
+  elseif(message_type STREQUAL STATUS)
+    list(REMOVE_AT ARGV 0)
+    _message("${green}[ INFO ]: ${ARGV}${color_reset}")
+  else()
+    _message("${green} ${ARGV} ${color_reset}")
+  endif()
 endfunction()
 
 #
@@ -33,340 +33,340 @@ endfunction()
 #
 macro(setup_geant4_target)
 
-    # Search for Geant4 and load its settings
-    find_package(Geant4 REQUIRED gdml ui_all vis_all)
+  # Search for Geant4 and load its settings
+  find_package(Geant4 REQUIRED gdml ui_all vis_all)
 
-    # Create an imported Geant4 target if it hasn't been done yet.
-    if( NOT TARGET Geant4::Interface) 
-    
-        #Geant4_DEFINITIONS already include -D, this leads to the error 
-        # <command-line>:0:1: error: macro names must be identifiers
-        # if not removed.
-        SET(G4_DEF_TEMP "")
-        foreach(def ${Geant4_DEFINITIONS})
-            string(REPLACE "-D" "" def ${def})
-            LIST(APPEND G4_DEF_TEMP ${def})
-        endforeach()
-        SET(LDMX_Geant4_DEFINITIONS ${G4_DEF_TEMP})
-        UNSET(G4_DEF_TEMP)
+  # Create an imported Geant4 target if it hasn't been done yet.
+  if( NOT TARGET Geant4::Interface) 
 
-        # Create the Geant4 target
-        add_library(Geant4::Interface INTERFACE IMPORTED GLOBAL)
+    #Geant4_DEFINITIONS already include -D, this leads to the error 
+    # <command-line>:0:1: error: macro names must be identifiers
+    # if not removed.
+    SET(G4_DEF_TEMP "")
+    foreach(def ${Geant4_DEFINITIONS})
+      string(REPLACE "-D" "" def ${def})
+      LIST(APPEND G4_DEF_TEMP ${def})
+    endforeach()
+    SET(LDMX_Geant4_DEFINITIONS ${G4_DEF_TEMP})
+    UNSET(G4_DEF_TEMP)
 
-        # Set the target properties
-        SET_TARGET_PROPERTIES(Geant4::Interface
-            PROPERTIES
-            INTERFACE_LINK_LIBRARIES "${Geant4_LIBRARIES}"
-            INTERFACE_COMPILE_OPTIONS "${Geant4_Flags}"
-            INTERFACE_COMPILE_DEFINITIONS "${LDMX_Geant4_DEFINITIONS}"
-            INTERFACE_INCLUDE_DIRECTORIES "${Geant4_INCLUDE_DIRS}"
-        )
+    # Create the Geant4 target
+    add_library(Geant4::Interface INTERFACE IMPORTED GLOBAL)
 
-        message(STATUS "Found Geant4 version ${Geant4_VERSION}")
-    
-    endif()
+    # Set the target properties
+    SET_TARGET_PROPERTIES(Geant4::Interface
+      PROPERTIES
+      INTERFACE_LINK_LIBRARIES "${Geant4_LIBRARIES}"
+      INTERFACE_COMPILE_OPTIONS "${Geant4_Flags}"
+      INTERFACE_COMPILE_DEFINITIONS "${LDMX_Geant4_DEFINITIONS}"
+      INTERFACE_INCLUDE_DIRECTORIES "${Geant4_INCLUDE_DIRS}"
+      )
+
+    message(STATUS "Found Geant4 version ${Geant4_VERSION}")
+
+  endif()
 
 endmacro()
 
 macro(setup_lcio_target)
-    
-    # If it doesn't exists, create an imported target for LCIO
-    if ( NOT TARGET LCIO::Interface)
-    
-        # Search for LCIO and load its settings
-        find_package(LCIO CONFIG REQUIRED)
 
-        # If the LCIO package can't be found, error out.
-        if( NOT LCIO_FOUND)
-            message(FATAL_ERROR "Failed to find required dependency LCIO.")
-        endif()
+  # If it doesn't exists, create an imported target for LCIO
+  if ( NOT TARGET LCIO::Interface)
 
-        # Create the LCIO target
-        add_library(LCIO::Interface SHARED IMPORTED GLOBAL)
+    # Search for LCIO and load its settings
+    find_package(LCIO CONFIG REQUIRED)
 
-        # Set the target properties
-        set_target_properties(LCIO::Interface
-            PROPERTIES
-            INTERFACE_INCLUDE_DIRECTORIES "${LCIO_INCLUDE_DIRS}"
-            IMPORTED_LOCATION "${LCIO_LIBRARY_DIRS}/liblcio.so"
-        )
-
-        message(STATUS "Found LCIO version ${LCIO_VERSION}")
-
+    # If the LCIO package can't be found, error out.
+    if( NOT LCIO_FOUND)
+      message(FATAL_ERROR "Failed to find required dependency LCIO.")
     endif()
+
+    # Create the LCIO target
+    add_library(LCIO::Interface SHARED IMPORTED GLOBAL)
+
+    # Set the target properties
+    set_target_properties(LCIO::Interface
+      PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${LCIO_INCLUDE_DIRS}"
+      IMPORTED_LOCATION "${LCIO_LIBRARY_DIRS}/liblcio.so"
+      )
+
+    message(STATUS "Found LCIO version ${LCIO_VERSION}")
+
+  endif()
 
 endmacro()
 
 macro(setup_library)
 
-    set(options interface register_target)
-    set(oneValueArgs module name python_install_path)
-    set(multiValueArgs dependencies sources)
-    cmake_parse_arguments(setup_library "${options}" "${oneValueArgs}"
-                          "${multiValueArgs}" ${ARGN} )
+  set(options interface register_target)
+  set(oneValueArgs module name python_install_path)
+  set(multiValueArgs dependencies sources)
+  cmake_parse_arguments(setup_library "${options}" "${oneValueArgs}"
+    "${multiValueArgs}" ${ARGN} )
 
 
-    # Build the library name and source path
-    set(library_name "${setup_library_name}")
-    set(src_path "${PROJECT_SOURCE_DIR}/src/${setup_library_name}")
-    set(include_path "include/${setup_library_name}")
-    if (setup_library_module)
-        set(library_name "${setup_library_module}_${setup_library_name}")
-        set(src_path "${PROJECT_SOURCE_DIR}/src/${setup_library_module}/${setup_library_name}")
-        set(include_path "include/${setup_library_module}/${setup_library_name}")
-    endif()
+  # Build the library name and source path
+  set(library_name "${setup_library_name}")
+  set(src_path "${PROJECT_SOURCE_DIR}/src/${setup_library_name}")
+  set(include_path "include/${setup_library_name}")
+  if (setup_library_module)
+    set(library_name "${setup_library_module}_${setup_library_name}")
+    set(src_path "${PROJECT_SOURCE_DIR}/src/${setup_library_module}/${setup_library_name}")
+    set(include_path "include/${setup_library_module}/${setup_library_name}")
+  endif()
 
-    # If not an interface, find all of the source files we want to add to the
-    # library.
-    if (NOT setup_library_interface)
-        if (NOT setup_library_sources)
-            file(GLOB SRC_FILES CONFIGURE_DEPENDS ${src_path}/*.cxx)
-        else()
-            set(SRC_FILES ${setup_library_sources})
-        endif()
-        
-        # Create the SimCore shared library
-        add_library(${library_name} SHARED ${SRC_FILES})
+  # If not an interface, find all of the source files we want to add to the
+  # library.
+  if (NOT setup_library_interface)
+    if (NOT setup_library_sources)
+      file(GLOB SRC_FILES CONFIGURE_DEPENDS ${src_path}/*.cxx)
     else()
-        add_library(${library_name} INTERFACE)
+      set(SRC_FILES ${setup_library_sources})
     endif()
 
-    # Setup the include directories 
-    if (setup_library_interface)
-        target_include_directories(${library_name} INTERFACE ${PROJECT_SOURCE_DIR}/include)
-    else()
-        target_include_directories(${library_name} PUBLIC ${PROJECT_SOURCE_DIR}/include)
-    endif()
+    # Create the SimCore shared library
+    add_library(${library_name} SHARED ${SRC_FILES})
+  else()
+    add_library(${library_name} INTERFACE)
+  endif()
 
-    # Setup the targets to link against 
-    target_link_libraries(${library_name} PUBLIC ${setup_library_dependencies})
+  # Setup the include directories 
+  if (setup_library_interface)
+    target_include_directories(${library_name} INTERFACE ${PROJECT_SOURCE_DIR}/include)
+  else()
+    target_include_directories(${library_name} PUBLIC ${PROJECT_SOURCE_DIR}/include)
+  endif()
 
-    # Define an alias. This is used to create the imported target.
-    set(alias "${setup_library_name}::${setup_library_name}")
-    if (setup_library_module)
-        set(alias "${setup_library_module}::${setup_library_name}")
-    endif()
-    add_library(${alias} ALIAS ${library_name})
+  # Setup the targets to link against 
+  target_link_libraries(${library_name} PUBLIC ${setup_library_dependencies})
 
-    if(setup_library_register_target)
-        set(registered_targets ${registered_targets} ${alias} CACHE INTERNAL "registered_targets")
-    endif()
+  # Define an alias. This is used to create the imported target.
+  set(alias "${setup_library_name}::${setup_library_name}")
+  if (setup_library_module)
+    set(alias "${setup_library_module}::${setup_library_name}")
+  endif()
+  add_library(${alias} ALIAS ${library_name})
 
-    # Install the libraries and headers
-    install(TARGETS ${library_name}
-            LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+  if(setup_library_register_target)
+    set(registered_targets ${registered_targets} ${alias} CACHE INTERNAL "registered_targets")
+  endif()
+
+  # Install the libraries and headers
+  install(TARGETS ${library_name}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
     )
-    install(DIRECTORY ${PROJECT_SOURCE_DIR}/${include_path}
-            DESTINATION ${CMAKE_INSTALL_PREFIX}/${include_path})
+  install(DIRECTORY ${PROJECT_SOURCE_DIR}/${include_path}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/${include_path})
 
 endmacro()
 
 macro(setup_python)
-   
-    set(oneValueArgs install_path)
-    cmake_parse_arguments(setup_python "${options}" "${oneValueArgs}"
-                          "${multiValueArgs}" ${ARGN} )
+
+  set(oneValueArgs install_path)
+  cmake_parse_arguments(setup_python "${options}" "${oneValueArgs}"
+    "${multiValueArgs}" ${ARGN} )
 
 
-    # If the python directory exists, initialize the package and copy over the 
-    # python modules.
-    if (EXISTS ${PROJECT_SOURCE_DIR}/python)
-       
-        # Install the python modules
-        file(GLOB py_scripts CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/python/*.py)
-        foreach(pyscript ${py_scripts})
-            string(REPLACE ".in" "" script_output ${pyscript})
-            get_filename_component(script_output ${script_output} NAME)
-            configure_file(${pyscript} ${CMAKE_CURRENT_BINARY_DIR}/python/${script_output})
-            install(FILES ${CMAKE_CURRENT_BINARY_DIR}/python/${script_output} DESTINATION ${setup_python_install_path})
-        endforeach()
+  # If the python directory exists, initialize the package and copy over the 
+  # python modules.
+  if (EXISTS ${PROJECT_SOURCE_DIR}/python)
 
-    endif()
+    # Install the python modules
+    file(GLOB py_scripts CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/python/*.py)
+    foreach(pyscript ${py_scripts})
+      string(REPLACE ".in" "" script_output ${pyscript})
+      get_filename_component(script_output ${script_output} NAME)
+      configure_file(${pyscript} ${CMAKE_CURRENT_BINARY_DIR}/python/${script_output})
+      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/python/${script_output} DESTINATION ${setup_python_install_path})
+    endforeach()
+
+  endif()
 
 endmacro()
 
 macro(setup_data)
 
-    # If the data directory exists, install it to the data directory
-    if (EXISTS ${PROJECT_SOURCE_DIR}/data)
-        file(GLOB data_files CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/data/*)
-        foreach(data_file ${data_files})
-            install(FILES ${data_file} DESTINATION ${CMAKE_INSTALL_PREFIX}/data/${setup_library_name})
-        endforeach()
-    endif()
+  # If the data directory exists, install it to the data directory
+  if (EXISTS ${PROJECT_SOURCE_DIR}/data)
+    file(GLOB data_files CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/data/*)
+    foreach(data_file ${data_files})
+      install(FILES ${data_file} DESTINATION ${CMAKE_INSTALL_PREFIX}/data/${setup_library_name})
+    endforeach()
+  endif()
 
 endmacro()
 
 function(register_event_object)
 
-    set(oneValueArgs module_path namespace class type key)
-    cmake_parse_arguments(register_event_object "${options}" "${oneValueArgs}"
-                          "${multiValueArgs}" ${ARGN} )
+  set(oneValueArgs module_path namespace class type key)
+  cmake_parse_arguments(register_event_object "${options}" "${oneValueArgs}"
+    "${multiValueArgs}" ${ARGN} )
 
-    # Start by checking if the class that is being registered exists
-    if(NOT EXISTS ${PROJECT_SOURCE_DIR}/include/${register_event_object_module_path}/${register_event_object_class}.h)
-        message(FATAL_ERROR "Trying to register class ${register_event_object_class} that doesn't exist.")
-    endif()
+  # Start by checking if the class that is being registered exists
+  if(NOT EXISTS ${PROJECT_SOURCE_DIR}/include/${register_event_object_module_path}/${register_event_object_class}.h)
+    message(FATAL_ERROR "Trying to register class ${register_event_object_class} that doesn't exist.")
+  endif()
 
-    set(header ${register_event_object_module_path}/${register_event_object_class}.h)
+  set(header ${register_event_object_module_path}/${register_event_object_class}.h)
 
-    if(DEFINED register_event_object_namespace)
-        STRING(CONCAT register_event_object_class
-                      ${register_event_object_namespace} "::" 
-                      ${register_event_object_class})
-    endif()
+  if(DEFINED register_event_object_namespace)
+    STRING(CONCAT register_event_object_class
+      ${register_event_object_namespace} "::" 
+      ${register_event_object_class})
+  endif()
 
-    # Only register objects that haven't already been registered.
-    if(register_event_object_class IN_LIST dict)
-        return()
-    endif()
+  # Only register objects that haven't already been registered.
+  if(register_event_object_class IN_LIST dict)
+    return()
+  endif()
 
-    set(dict ${dict} ${register_event_object_class} CACHE INTERNAL "dict")
+  set(dict ${dict} ${register_event_object_class} CACHE INTERNAL "dict")
 
-    set(event_headers ${event_headers} ${header} CACHE INTERNAL "event_headers")
+  set(event_headers ${event_headers} ${header} CACHE INTERNAL "event_headers")
 
-    if(NOT ${PROJECT_SOURCE_DIR}/include IN_LIST include_paths)
-        set(include_paths ${PROJECT_SOURCE_DIR}/include ${include_paths} CACHE INTERNAL "include_paths")
-    endif()
+  if(NOT ${PROJECT_SOURCE_DIR}/include IN_LIST include_paths)
+    set(include_paths ${PROJECT_SOURCE_DIR}/include ${include_paths} CACHE INTERNAL "include_paths")
+  endif()
 
-    # If the passenger type was not specified, then add the class to the event
-    # bus stand alone.
-    if(NOT DEFINED register_event_object_type)
-        set(bus_passengers ${bus_passengers} ${register_event_object_class} CACHE INTERNAL "bus_passengers")
-    elseif(register_event_object_type STREQUAL "collection")
-        set(bus_passengers ${bus_passengers} 
-            "std::vector< ${register_event_object_class} >" CACHE INTERNAL "bus_passengers")
-        set(dict ${dict} ${register_event_object_class} 
-            "std::vector< ${register_event_object_class} >" CACHE INTERNAL "dict")
-    elseif(register_event_object_type STREQUAL "map")
-        set(bus_passengers ${bus_passengers}
-            "std::map< ${register_event_object_key}, ${register_event_object_class} >" 
-            CACHE INTERNAL "bus_passengers")
-        set(dict ${dict}
-            "std::map< ${register_event_object_key}, ${register_event_object_class} >" 
-            CACHE INTERNAL "dict")
-    elseif(NOT register_event_object_type STREQUAL "dict_only")
-        message(FATAL_ERROR "Trying to register object with invalid type ${register_event_object_type}")
-    endif()
-    
+  # If the passenger type was not specified, then add the class to the event
+  # bus stand alone.
+  if(NOT DEFINED register_event_object_type)
+    set(bus_passengers ${bus_passengers} ${register_event_object_class} CACHE INTERNAL "bus_passengers")
+  elseif(register_event_object_type STREQUAL "collection")
+    set(bus_passengers ${bus_passengers} 
+      "std::vector< ${register_event_object_class} >" CACHE INTERNAL "bus_passengers")
+    set(dict ${dict} ${register_event_object_class} 
+      "std::vector< ${register_event_object_class} >" CACHE INTERNAL "dict")
+  elseif(register_event_object_type STREQUAL "map")
+    set(bus_passengers ${bus_passengers}
+      "std::map< ${register_event_object_key}, ${register_event_object_class} >" 
+      CACHE INTERNAL "bus_passengers")
+    set(dict ${dict}
+      "std::map< ${register_event_object_key}, ${register_event_object_class} >" 
+      CACHE INTERNAL "dict")
+  elseif(NOT register_event_object_type STREQUAL "dict_only")
+    message(FATAL_ERROR "Trying to register object with invalid type ${register_event_object_type}")
+  endif()
+
 endfunction()
 
 macro(build_event_bus)
 
-    set(oneValueArgs path)
-    cmake_parse_arguments(build_event_bus "${options}" "${oneValueArgs}"
-                          "${multiValueArgs}" ${ARGN} )
+  set(oneValueArgs path)
+  cmake_parse_arguments(build_event_bus "${options}" "${oneValueArgs}"
+    "${multiValueArgs}" ${ARGN} )
 
-    if(build_event_bus_path AND NOT EXISTS ${build_event_bus_path})
-       
-        foreach(header ${event_headers})
-            file(APPEND ${build_event_bus_path} "#include \"${header}\"\n")
-        endforeach()
-        
-        list(LENGTH bus_passengers passenger_count)
-        MATH(EXPR last_passenger_index "${passenger_count} - 1")
-        list(GET bus_passengers ${last_passenger_index} last_passenger)
-        list(REMOVE_AT bus_passengers ${last_passenger_index})
+  if(build_event_bus_path AND NOT EXISTS ${build_event_bus_path})
 
-        file(APPEND ${build_event_bus_path} "\n#include <variant>\n\n")
-        file(APPEND ${build_event_bus_path} "typedef std::variant<\n")
-        foreach(passenger ${bus_passengers})
-            file(APPEND ${build_event_bus_path} "    ${passenger},\n")
-        endforeach()
-        
-        file(APPEND ${build_event_bus_path} "    ${last_passenger}\n")
-        file(APPEND ${build_event_bus_path} "> EventBusPassenger;")
+    foreach(header ${event_headers})
+      file(APPEND ${build_event_bus_path} "#include \"${header}\"\n")
+    endforeach()
 
-    endif()
+    list(LENGTH bus_passengers passenger_count)
+    MATH(EXPR last_passenger_index "${passenger_count} - 1")
+    list(GET bus_passengers ${last_passenger_index} last_passenger)
+    list(REMOVE_AT bus_passengers ${last_passenger_index})
+
+    file(APPEND ${build_event_bus_path} "\n#include <variant>\n\n")
+    file(APPEND ${build_event_bus_path} "typedef std::variant<\n")
+    foreach(passenger ${bus_passengers})
+      file(APPEND ${build_event_bus_path} "    ${passenger},\n")
+    endforeach()
+
+    file(APPEND ${build_event_bus_path} "    ${last_passenger}\n")
+    file(APPEND ${build_event_bus_path} "> EventBusPassenger;")
+
+  endif()
 
 endmacro()
 
 macro(build_dict)
 
-    set(oneValueArgs template namespace)
-    cmake_parse_arguments(build_dict "${options}" "${oneValueArgs}"
-                          "${multiValueArgs}" ${ARGN} )
+  set(oneValueArgs template namespace)
+  cmake_parse_arguments(build_dict "${options}" "${oneValueArgs}"
+    "${multiValueArgs}" ${ARGN} )
 
-    get_filename_component(header_dir ${PROJECT_SOURCE_DIR} NAME)
-    if(NOT EXISTS ${PROJECT_SOURCE_DIR}/include/${header_dir}/EventLinkDef.h)
+  get_filename_component(header_dir ${PROJECT_SOURCE_DIR} NAME)
+  if(NOT EXISTS ${PROJECT_SOURCE_DIR}/include/${header_dir}/EventLinkDef.h)
 
-        message(STATUS "Building ROOT dictionary.")
-        if(DEFINED build_dict_template)
-            configure_file(
-                ${build_dict_template}
-                ${PROJECT_SOURCE_DIR}/include/${header_dir}/EventLinkDef.h 
-                COPYONLY
-            )
-        endif()
-
-        set(file_path ${PROJECT_SOURCE_DIR}/include/${header_dir}/EventLinkDef.h)
-        set(prefix "#pragma link C++")
-
-        if(DEFINED build_dict_namespace)
-            file(APPEND ${file_path} "${prefix} namespace ${build_dict_namespace};\n")
-            file(APPEND ${file_path} "${prefix} defined_in namespace ${build_dict_namespace};\n\n")
-        endif()
-
-        foreach(entry ${dict})
-            file(APPEND ${file_path} "${prefix} class ${entry}+;\n")
-        endforeach()
-
-        file(APPEND ${file_path} "\n#endif")
-
+    message(STATUS "Building ROOT dictionary.")
+    if(DEFINED build_dict_template)
+      configure_file(
+        ${build_dict_template}
+        ${PROJECT_SOURCE_DIR}/include/${header_dir}/EventLinkDef.h 
+        COPYONLY
+        )
     endif()
-    
+
+    set(file_path ${PROJECT_SOURCE_DIR}/include/${header_dir}/EventLinkDef.h)
+    set(prefix "#pragma link C++")
+
+    if(DEFINED build_dict_namespace)
+      file(APPEND ${file_path} "${prefix} namespace ${build_dict_namespace};\n")
+      file(APPEND ${file_path} "${prefix} defined_in namespace ${build_dict_namespace};\n\n")
+    endif()
+
+    foreach(entry ${dict})
+      file(APPEND ${file_path} "${prefix} class ${entry}+;\n")
+    endforeach()
+
+    file(APPEND ${file_path} "\n#endif")
+
+  endif()
+
 endmacro()
 
 macro(setup_test)
 
-    set(multiValueArgs dependencies)
-    cmake_parse_arguments(setup_test "${options}" "${oneValueArgs}"
-                          "${multiValueArgs}" ${ARGN} )
+  set(multiValueArgs dependencies)
+  cmake_parse_arguments(setup_test "${options}" "${oneValueArgs}"
+    "${multiValueArgs}" ${ARGN} )
 
-    # Find all the test
-    file(GLOB src_files CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/test/*.cxx)
+  # Find all the test
+  file(GLOB src_files CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/test/*.cxx)
 
-    # Add all test to the global list of test sources 
-    set(test_sources ${test_sources} ${src_files} CACHE INTERNAL "test_sources")
+  # Add all test to the global list of test sources 
+  set(test_sources ${test_sources} ${src_files} CACHE INTERNAL "test_sources")
 
-    # Add all of the dependencies to the global list of dependencies 
-    set(test_dep ${test_dep} ${setup_test_dependencies} CACHE INTERNAL "test_dep")
+  # Add all of the dependencies to the global list of dependencies 
+  set(test_dep ${test_dep} ${setup_test_dependencies} CACHE INTERNAL "test_dep")
 
 endmacro()
 
 macro(build_test)
 
-    # If test have been enabled, attempt to find catch.  If catch hasn't 
-    # found, it will be downloaded locally.
-    find_package(Catch2 2.13.0)
+  # If test have been enabled, attempt to find catch.  If catch hasn't 
+  # found, it will be downloaded locally.
+  find_package(Catch2 2.13.0)
 
-    # Create the Catch2 main exectuable if it doesn't exist
-    if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/external/catch/run_test.cxx)
-    
-        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/external/catch/run_test.cxx
-             "#define CATCH_CONFIG_MAIN\n#include \"catch.hpp\""
-        )
-        
-        message(STATUS "Writing Catch2 main to: ${CMAKE_CURRENT_BINARY_DIR}/external/catch/run_test.cxx")
-    endif()
+  # Create the Catch2 main exectuable if it doesn't exist
+  if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/external/catch/run_test.cxx)
 
-    # Add the executable to run all test.  test_sources is a cached variable 
-    # that contains the test from the different modules.  Each of the modules
-    # needs to setup the test they want to run.
-    add_executable(run_test ${CMAKE_CURRENT_BINARY_DIR}/external/catch/run_test.cxx ${test_sources})
-    target_include_directories(run_test PRIVATE ${CATCH2_INCLUDE_DIR})
-    target_link_libraries(run_test PRIVATE Catch2::Interface ${test_dep})
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/external/catch/run_test.cxx
+      "#define CATCH_CONFIG_MAIN\n#include \"catch.hpp\""
+      )
 
-    # Install the run_test  executable
-    install(TARGETS run_test DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+    message(STATUS "Writing Catch2 main to: ${CMAKE_CURRENT_BINARY_DIR}/external/catch/run_test.cxx")
+  endif()
+
+  # Add the executable to run all test.  test_sources is a cached variable 
+  # that contains the test from the different modules.  Each of the modules
+  # needs to setup the test they want to run.
+  add_executable(run_test ${CMAKE_CURRENT_BINARY_DIR}/external/catch/run_test.cxx ${test_sources})
+  target_include_directories(run_test PRIVATE ${CATCH2_INCLUDE_DIR})
+  target_link_libraries(run_test PRIVATE Catch2::Interface ${test_dep})
+
+  # Install the run_test  executable
+  install(TARGETS run_test DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 
 endmacro()
 
 macro(clear_cache_variables)
-    unset(registered_targets CACHE)
-    unset(dict CACHE)
-    unset(event_headers CACHE)
-    unset(bus_passengers CACHE)
-    unset(test_sources CACHE)
-    unset(test_dep CACHE)
+  unset(registered_targets CACHE)
+  unset(dict CACHE)
+  unset(event_headers CACHE)
+  unset(bus_passengers CACHE)
+  unset(test_sources CACHE)
+  unset(test_dep CACHE)
 endmacro()

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -137,7 +137,6 @@ macro(setup_library)
   endif()
 
   # Setup the targets to link against
-  message(STATUS "Library name: ${library_name}")
   target_link_libraries(${library_name} PUBLIC ${setup_library_dependencies})
 
   # Define an alias. This is used to create the imported target.

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -111,6 +111,19 @@ macro(setup_library)
         set(SRC_FILES ${setup_library_sources})
     endif()
 
+    #NOT SURE IF NEEDED
+    #   do I need to remove the source files that were compiled into the 
+    #   event bus dictionary? Or is it okay for them to be compiled twice?
+#    set(link_against_dictionary "NO")
+#    foreach(src ${SRC_FILES})
+#        list(FIND event_sources ${src} index)
+#        if(${index} GREATER 0)
+#            #found ==> is an event passenger
+#            list(REMOVE_ITEM SRC_FILES ${src})
+#            set(link_against_dictionary "YES")
+#        endif()
+#    endforeach()
+
     # Create the SimCore shared library
     add_library(${setup_library_name} SHARED ${SRC_FILES})
 
@@ -118,6 +131,9 @@ macro(setup_library)
     target_include_directories(${setup_library_name} PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
     # Setup the targets to link against 
+#    if(${link_against_dictionary} STREQUAL "YES")
+#        list(APPEND setup_library_dependencies "DARK::Event")
+#    endif()
     target_link_libraries(${setup_library_name} PUBLIC ${setup_library_dependencies})
 
     # Define an alias. This is used to create the imported target.
@@ -222,6 +238,11 @@ macro(setup_dictionary)
 
 
     message("Writing ROOT Dictionary for ${setup_dictionary_module}")
+
+    list(REMOVE_DUPLICATES event_classes)
+    list(REMOVE_DUPLICATES event_headers)
+    list(REMOVE_DUPLICATES event_sources)
+
     message("Event Classes:'${event_classes}'")
     message("Event Headers:'${event_headers}'")
     

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -1,4 +1,3 @@
-
 include(CMakeParseArguments)
 
 # Define some colors. These are used to colorize CMake's user output
@@ -171,15 +170,30 @@ macro(setup_python)
   # python modules.
   if(EXISTS ${PROJECT_SOURCE_DIR}/python)
 
-    # Install the python modules
-    file(GLOB py_scripts CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/python/*.py)
+    # Get a list of all python files inside the python package
+    file(GLOB py_scripts CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/python/*.py
+                                           ${PROJECT_SOURCE_DIR}/python/*.py.in)
+
     foreach(pyscript ${py_scripts})
+
+      # If a filename has a '.in' extension, remove it.  The '.in' extension is
+      # used to denote files that have variables that will be substituded by the
+      # configure_file macro.
       string(REPLACE ".in" "" script_output ${pyscript})
+
+      # GLOB returns the full path to the file.  We also need the filename so
+      # it's new location can be specified.
       get_filename_component(script_output ${script_output} NAME)
+
+      # Copy the file from its original location to the bin directory.  This
+      # will also replace all cmake variables within the files.
       configure_file(${pyscript}
                      ${CMAKE_CURRENT_BINARY_DIR}/python/${script_output})
-      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/python/${script_output}
-              DESTINATION ${setup_python_install_path})
+
+      # Install the files to the given path
+      install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/python/${script_output}
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/python/${setup_python_package_name})
     endforeach()
 
   endif()

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -161,30 +161,41 @@ macro(setup_library)
 
 endmacro()
 
+macro(setup_python)
+   
+    set(oneValueArgs install_path)
+    cmake_parse_arguments(setup_python "${options}" "${oneValueArgs}"
+                          "${multiValueArgs}" ${ARGN} )
 
 
-# If the python directory exists, initialize the package and copy over the 
+    # If the python directory exists, initialize the package and copy over the 
     # python modules.
-    #if (EXISTS ${PROJECT_SOURCE_DIR}/python)
+    if (EXISTS ${PROJECT_SOURCE_DIR}/python)
        
         # Install the python modules
-        #    file(GLOB py_scripts CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/python/*.py)
-        #foreach(pyscript ${py_scripts})
-        #    string(REPLACE ".in" "" script_output ${pyscript})
-        #    get_filename_component(script_output ${script_output} NAME)
-        #    configure_file(${pyscript} ${CMAKE_CURRENT_BINARY_DIR}/python/${script_output})
-        #    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/python/${script_output} DESTINATION ${setup_library_python_install_path}/${setup_library_name})
-        #endforeach()
+        file(GLOB py_scripts CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/python/*.py)
+        foreach(pyscript ${py_scripts})
+            string(REPLACE ".in" "" script_output ${pyscript})
+            get_filename_component(script_output ${script_output} NAME)
+            configure_file(${pyscript} ${CMAKE_CURRENT_BINARY_DIR}/python/${script_output})
+            install(FILES ${CMAKE_CURRENT_BINARY_DIR}/python/${script_output} DESTINATION ${setup_python_install_path})
+        endforeach()
 
-        #endif()
+    endif()
+
+endmacro()
+
+macro(setup_data)
 
     # If the data directory exists, install it to the data directory
-    #if (EXISTS ${PROJECT_SOURCE_DIR}/data)
-    #    file(GLOB data_files CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/data/*)
-    #    foreach(data_file ${data_files})
-    #        install(FILES ${data_file} DESTINATION ${CMAKE_INSTALL_PREFIX}/data/${setup_library_name})
-    #    endforeach()
-    #endif()
+    if (EXISTS ${PROJECT_SOURCE_DIR}/data)
+        file(GLOB data_files CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/data/*)
+        foreach(data_file ${data_files})
+            install(FILES ${data_file} DESTINATION ${CMAKE_INSTALL_PREFIX}/data/${setup_library_name})
+        endforeach()
+    endif()
+
+endmacro()
 
 function(register_event_object)
 

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -304,41 +304,44 @@ macro(build_event_bus)
       file(APPEND ${build_event_bus_path} "#include \"${header}\"\n")
     endforeach()
 
-    list(LENGTH bus_passengers passenger_count)
-    math(EXPR last_passenger_index "${passenger_count} - 1")
-    list(GET bus_passengers ${last_passenger_index} last_passenger)
-    list(REMOVE_AT bus_passengers ${last_passenger_index})
+    if(bus_passengers)
 
-    file(APPEND ${build_event_bus_path} "\n#include <variant>\n\n")
-    file(APPEND ${build_event_bus_path} "typedef std::variant<\n")
-    foreach(passenger ${bus_passengers})
-      file(APPEND ${build_event_bus_path} "    ${passenger},\n")
-    endforeach()
+      list(LENGTH bus_passengers passenger_count)
+      math(EXPR last_passenger_index "${passenger_count} - 1")
+      list(GET bus_passengers ${last_passenger_index} last_passenger)
+      list(REMOVE_AT bus_passengers ${last_passenger_index})
 
-    file(APPEND ${build_event_bus_path} "    ${last_passenger}\n")
-    file(APPEND ${build_event_bus_path} "> EventBusPassenger;")
+      file(APPEND ${build_event_bus_path} "\n#include <variant>\n\n")
+      file(APPEND ${build_event_bus_path} "typedef std::variant<\n")
+      foreach(passenger ${bus_passengers})
+        file(APPEND ${build_event_bus_path} "    ${passenger},\n")
+      endforeach()
 
+      file(APPEND ${build_event_bus_path} "    ${last_passenger}\n")
+      file(APPEND ${build_event_bus_path} "> EventBusPassenger;")
+
+    endif()
   endif()
 
 endmacro()
 
 macro(build_dict)
 
-  set(oneValueArgs template namespace)
+  set(oneValueArgs name namespace template)
   cmake_parse_arguments(build_dict "${options}" "${oneValueArgs}"
                         "${multiValueArgs}" ${ARGN})
 
   get_filename_component(header_dir ${PROJECT_SOURCE_DIR} NAME)
-  if(NOT EXISTS ${PROJECT_SOURCE_DIR}/include/${header_dir}/EventLinkDef.h)
+  if(NOT EXISTS ${PROJECT_SOURCE_DIR}/include/${header_dir}/${build_dict_name}LinkDef.h)
 
     message(STATUS "Building ROOT dictionary.")
     if(DEFINED build_dict_template)
       configure_file(
         ${build_dict_template}
-        ${PROJECT_SOURCE_DIR}/include/${header_dir}/EventLinkDef.h COPYONLY)
+        ${PROJECT_SOURCE_DIR}/include/${header_dir}/${build_dict_name}LinkDef.h COPYONLY)
     endif()
 
-    set(file_path ${PROJECT_SOURCE_DIR}/include/${header_dir}/EventLinkDef.h)
+    set(file_path ${PROJECT_SOURCE_DIR}/include/${header_dir}/${build_dict_name}LinkDef.h)
     set(prefix "#pragma link C++")
 
     if(DEFINED build_dict_namespace)

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -367,7 +367,7 @@ macro(setup_test)
                         "${multiValueArgs}" ${ARGN})
 
   # Find all the test
-  file(GLOB src_files CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/test/[a-zA-Z].cxx)
+  file(GLOB src_files CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/test/[a-zA-Z]*.cxx)
 
   # Add all test to the global list of test sources
   set(test_sources
@@ -379,6 +379,7 @@ macro(setup_test)
       ${test_dep} ${setup_test_dependencies}
       CACHE INTERNAL "test_dep")
 
+    message(STATUS ${test_sources})
 endmacro()
 
 macro(build_test)

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -202,12 +202,16 @@ endmacro()
 
 macro(setup_data)
 
+  set(oneValueArgs module)
+  cmake_parse_arguments(setup_data "${options}" "${oneValueArgs}"
+                        "${multiValueArgs}" ${ARGN})
+
   # If the data directory exists, install it to the data directory
   if(EXISTS ${PROJECT_SOURCE_DIR}/data)
     file(GLOB data_files CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/data/*)
     foreach(data_file ${data_files})
       install(FILES ${data_file}
-              DESTINATION ${CMAKE_INSTALL_PREFIX}/data/${setup_library_name})
+              DESTINATION ${CMAKE_INSTALL_PREFIX}/data/${setup_data_module})
     endforeach()
   endif()
 

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -379,10 +379,16 @@ macro(setup_test)
       ${test_dep} ${setup_test_dependencies}
       CACHE INTERNAL "test_dep")
 
-    message(STATUS ${test_sources})
+  # Add the module to the list of tags
+  get_filename_component(module ${PROJECT_SOURCE_DIR} NAME) 
+  set(test_modules ${test_modules} ${module} 
+      CACHE INTERNAL "test_modules")
+
 endmacro()
 
 macro(build_test)
+
+  enable_testing()
 
   # If test have been enabled, attempt to find catch.  If catch hasn't found, it
   # will be downloaded locally.
@@ -410,7 +416,9 @@ macro(build_test)
   target_link_libraries(run_test PRIVATE Catch2::Interface ${test_dep})
 
   # Install the run_test  executable
-  install(TARGETS run_test DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+  foreach(entry ${test_modules})
+    add_test(NAME ${entry} COMMAND run_test "[${entry}]")
+  endforeach()
 
 endmacro()
 
@@ -421,4 +429,5 @@ macro(clear_cache_variables)
   unset(bus_passengers CACHE)
   unset(test_sources CACHE)
   unset(test_dep CACHE)
+  unset(test_modules CACHE)
 endmacro()

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -245,6 +245,44 @@ macro(build_event_bus)
 
 endmacro()
 
+macro(build_dict)
+
+    set(oneValueArgs template namespace)
+    cmake_parse_arguments(build_dict "${options}" "${oneValueArgs}"
+                          "${multiValueArgs}" ${ARGN} )
+
+    get_filename_component(header_dir ${PROJECT_SOURCE_DIR} NAME)
+    if(NOT EXISTS ${PROJECT_SOURCE_DIR}/include/${header_dir}/EventLinkDef.h)
+
+        message(STATUS "Building ROOT dictionary.")
+        message(STATUS "${build_dict_template}")
+        if(DEFINED build_dict_template)
+            configure_file(
+                ${build_dict_template}
+                ${PROJECT_SOURCE_DIR}/include/${header_dir}/EventLinkDef.h 
+                COPYONLY
+            )
+        endif()
+
+        set(file_path ${PROJECT_SOURCE_DIR}/include/${header_dir}/EventLinkDef.h)
+        set(prefix "#pragma link C++")
+
+        if(DEFINED build_dict_namespace)
+            file(APPEND ${file_path} "${prefix} namespace ${build_dict_namespace}\n")
+            file(APPEND ${file_path} "${prefix} defined_in namespace ${build_dict_namespace}\n\n")
+        endif()
+
+        foreach(entry ${dict})
+            file(APPEND ${file_path} "${prefix} class ${entry}+;\n")
+        endforeach()
+
+        file(APPEND ${file_path} "\n#endif")
+
+    endif()
+    
+
+endmacro()
+
 macro(setup_test)
 
     set(multiValueArgs dependencies)

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -155,6 +155,56 @@ macro(setup_library)
 
 endmacro()
 
+macro(declare_event_object)
+
+    # declare a class to be an event bus passenger
+    #   class is the name of the class (required)
+    #   module is the module the class is defined in (required)
+    #   namespace is the namespace the class is defined in (default "ldmx")
+    #   if collection is defined, then the event bus passenger is added as a vector
+    #       e.g. collection "ON"
+    #   if map is defined, then the event bus passenger is the value and the key is
+    #       what map is defined as (e.g. map "int")
+
+    set(oneValueArgs 
+        class module namespace collection map
+        )
+    cmake_parse_arguments(declare_event_object "${options}" "${oneValueArgs}"
+                          "${multiValueArgs}" ${ARGN} )
+
+    set(full_class_name "ldmx::${declare_event_object_class}")
+    if(DEFINED declare_event_object_namespace)
+        set(full_class_name "${declare_event_object_namespace}::${declare_event_object_class}")
+    endif()
+
+    # Add all event objects to global list of event objects
+    set(event_classes ${event_classes} 
+        ${full_class_name}
+        CACHE INTERNAL "event_classes" )
+    set(event_headers ${event_headers} 
+        ${PROJECT_SOURCE_DIR}/include/${declare_event_object_module}/${declare_event_object_class}.h
+        CACHE INTERNAL "event_headers" )
+
+    if(EXISTS ${PROJECT_SOURCE_DIR}/src/${declare_event_object_class}.cxx)
+        set(event_sources ${event_sources} 
+            ${PROJECT_SOURCE_DIR}/src/${declare_event_object_class}.cxx
+            CACHE INTERNAL "event_sources" )
+    endif()
+
+    if(DEFINED declare_event_object_collection)
+        set(event_classes ${event_classes} 
+            "std::vector<${full_class_name}>"
+            CACHE INTERNAL "event_classes" )
+    endif()
+
+    if(DEFINED declare_event_object_map)
+        set(event_classes ${event_classes}
+            "std::map<${declare_event_object_map},${full_class_name}>"
+            CACHE INTERNAL "event_classes" )
+    endif()
+
+endmacro()
+
 macro(setup_test)
 
     set(multiValueArgs dependencies)

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -350,3 +350,12 @@ macro(build_test)
     install(TARGETS run_test DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 
 endmacro()
+
+macro(clear_cache_variables)
+    unset(registered_targets CACHE)
+    unset(dict CACHE)
+    unset(event_headers CACHE)
+    unset(bus_passengers CACHE)
+    unset(test_sources CACHE)
+    unset(test_dep CACHE)
+endmacro()

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -95,7 +95,7 @@ endmacro()
 macro(setup_library)
 
   set(options interface register_target)
-  set(oneValueArgs module name python_install_path)
+  set(oneValueArgs module name)
   set(multiValueArgs dependencies sources)
   cmake_parse_arguments(setup_library "${options}" "${oneValueArgs}"
                         "${multiValueArgs}" ${ARGN})

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -106,17 +106,15 @@ macro(setup_library)
   set(include_path "include/${setup_library_module}")
   if(setup_library_name)
     set(library_name "${setup_library_module}_${setup_library_name}")
-    set(src_path
-        "${PROJECT_SOURCE_DIR}/src/${setup_library_module}/${setup_library_name}"
-    )
-    set(include_path "include/${setup_library_module}/${setup_library_name}")
+    set(src_path "${src_path}/${setup_library_name}")
+    set(include_path "${include_path}/${setup_library_name}")
   endif()
 
   # If not an interface, find all of the source files we want to add to the
   # library.
   if(NOT setup_library_interface)
     if(NOT setup_library_sources)
-      file(GLOB SRC_FILES CONFIGURE_DEPENDS ${src_path}/*.cxx)
+      file(GLOB SRC_FILES CONFIGURE_DEPENDS ${src_path}/[a-zA-Z]*.cxx)
     else()
       set(SRC_FILES ${setup_library_sources})
     endif()
@@ -171,8 +169,8 @@ macro(setup_python)
   if(EXISTS ${PROJECT_SOURCE_DIR}/python)
 
     # Get a list of all python files inside the python package
-    file(GLOB py_scripts CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/python/*.py
-                                           ${PROJECT_SOURCE_DIR}/python/*.py.in)
+    file(GLOB py_scripts CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/python/[a-zA-Z]*.py
+                                           ${PROJECT_SOURCE_DIR}/python/[a-zA-Z]*.py.in)
 
     foreach(pyscript ${py_scripts})
 
@@ -366,7 +364,7 @@ macro(setup_test)
                         "${multiValueArgs}" ${ARGN})
 
   # Find all the test
-  file(GLOB src_files CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/test/*.cxx)
+  file(GLOB src_files CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/test/[a-zA-Z].cxx)
 
   # Add all test to the global list of test sources
   set(test_sources

--- a/FindGDML.cmake
+++ b/FindGDML.cmake
@@ -1,0 +1,40 @@
+#
+# FindGDML.cmake
+#
+# Finds the ONNX Runtime binaries or download them if a suitable version 
+# isn't found.
+#
+# This will define the following variables
+#   
+#   GDML_FOUND        
+#   GDML_INCLUDE_DIRS - path to headers
+#   GDML_LIBRARIES    - path to libraries
+# 
+# and the following targets
+#
+#   GDML::GDML
+#
+
+if(NOT TARGET GDML::GDML)
+
+  find_path(gdml_include_dir
+            NAMES SAXProcessor.h
+            PATHS ${GDML_DIR}/include
+            PATH_SUFFIXES Saxana)
+
+  # If GDML can't be found, throw a fatal error.
+  if(NOT gdml_include_dir)
+    message(FATAL_ERROR "GDML was not found. Specify the install directory by setting GDML_DIR.")
+  endif()
+
+  # Create the target
+  add_library(GDML::GDML SHARED IMPORTED GLOBAL)
+  set_target_properties(GDML::GDML
+                        PROPERTIES
+                        INTERFACE_INCLUDE_DIRECTORIES "${GDML_DIR}/include"
+                        IMPORTED_LOCATION "${GDML_DIR}/lib/libgdml.so")
+  
+  message(STATUS "Found GDML at ${GDML_DIR}")
+  set(GDML_FOUND TRUE)
+
+endif()

--- a/FindLCDD.cmake
+++ b/FindLCDD.cmake
@@ -1,0 +1,40 @@
+#
+# FindLCDD.cmake
+#
+# Finds the ONNX Runtime binaries or download them if a suitable version 
+# isn't found.
+#
+# This will define the following variables
+#   
+#   LCDD_FOUND        
+#   LCDD_INCLUDE_DIRS - path to headers
+#   LCDD_LIBRARIES    - path to libraries
+# 
+# and the following targets
+#
+#   LCDD::LCDD
+#
+
+if(NOT TARGET LCDD::LCDD)
+
+  find_path(lcdd_include_dir
+            NAMES LCDDParser.hh
+            PATHS ${LCDD_DIR}/include
+            PATH_SUFFIXES lcdd/core)
+
+  # If LCDD can't be found, throw a fatal error.
+  if(NOT lcdd_include_dir)
+    message(FATAL_ERROR "LCDD was not found. Specify the install directory by setting LCDD_DIR.")
+  endif()
+
+  # Create the target
+  add_library(LCDD::LCDD SHARED IMPORTED GLOBAL)
+  set_target_properties(LCDD::LCDD
+                        PROPERTIES
+                        INTERFACE_INCLUDE_DIRECTORIES "${LCDD_DIR}/include"
+                        IMPORTED_LOCATION "${LCDD_DIR}/lib/liblcdd.so")
+  
+  message(STATUS "Found LCDD at ${LCDD_DIR}")
+  set(LCDD_FOUND TRUE)
+
+endif()


### PR DESCRIPTION
This PR has two macros added:

### declare_event_object
Adds class to the list of objects that need to be compiled into the `DARK::Event` target.
The arguments allow for the user to decide if the object is added to the bus by itself, as a entry in a vector, or as the value in a map where the key can be defined by the user.

### setup_dictionary
Use the previously declared event objects to write an EventDef.h and EventLinkDef.h that can be used to generate an EventDict.cxx and compiled into the DARK::Event target. This macro is only called in the Framework module right now.

Also, in `setup_library` I check if any of the source files are already listed to be compiled into the event library. If they are, those source files are skipped and the `DARK::Event` target is added to the link dependencies.