### PR TITLE
Iss644 Testing - Include configurations in test executable

### DIFF
--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -360,18 +360,9 @@ macro(setup_test)
   cmake_parse_arguments(setup_test "${options}" "${oneValueArgs}"
                         "${multiValueArgs}" ${ARGN})
 
-  # Assume `.py` files should be run through the process
-  file(GLOB more_test_configs CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/test/*.py)
-  foreach(config_path ${test_configs})
-    get_filename_component(config ${config_path} NAME)
-    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/test/${config}.cxx
-        "#include \"catch.hpp\"\n#include \"Framework/Testing.h\"\n\nTEST_CASE(\"Run ${config}\",\"[${PROJECT_NAME}][full-run]\") {\nCHECK_THAT( \"${config_path}\" , ldmx::test::fires() );\n}"
-        )
-    list(APPEND src_files ${CMAKE_CURRENT_BINARY_DIR}/test/${config}.cxx)
-  endforeach()
-
   # Find all the test, including any that needed to be configured and put into the binary directory
-  file(GLOB src_files CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/test/*.cxx ${CMAKE_CURRENT_BINARY_DIR}/test/*.cxx)
+  file(GLOB src_files CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/test/*.cxx 
+                                        ${CMAKE_CURRENT_BINARY_DIR}/test/*.cxx)
 
   # Add all test to the global list of test sources
   set(test_sources
@@ -382,6 +373,9 @@ macro(setup_test)
   set(test_dep
       ${test_dep} ${setup_test_dependencies}
       CACHE INTERNAL "test_dep")
+
+  # Assume `.py` files should be run through the process
+  file(GLOB more_test_configs CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/test/*.py)
 
   # Add configs to the global list of test configs to run
   set(test_configs

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -112,8 +112,7 @@ macro(setup_library)
     set(include_path "include/${setup_library_module}/${setup_library_name}")
   endif()
 
-  # If not an interface, find all of the source files we want to add to the
-  # library.
+  # If not an interface, find all of the source files we want to add to the library.
   if(NOT setup_library_interface)
     if(NOT setup_library_sources)
       file(GLOB SRC_FILES CONFIGURE_DEPENDS ${src_path}/*.cxx)
@@ -156,7 +155,7 @@ macro(setup_library)
   install(TARGETS ${library_name}
           LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
   install(DIRECTORY ${PROJECT_SOURCE_DIR}/${include_path}
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/${include_path})
+          DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
 
 endmacro()
 

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -366,7 +366,7 @@ macro(setup_test)
   foreach(config_path ${test_configs})
     get_filename_component(config ${config_path} NAME)
     file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/test/${config}.cxx
-        "#include \"catch.hpp\"\n#include \"Framework/Testing.h\"\n\nTEST_CASE(\"Run ${config}\",\"[${PROJECT_NAME}]\") {\nCHECK_THAT( \"${config_path}\" , ldmx::test::fires() );\n}"
+        "#include \"catch.hpp\"\n#include \"Framework/Testing.h\"\n\nTEST_CASE(\"Run ${config}\",\"[${PROJECT_NAME}][full-run]\") {\nCHECK_THAT( \"${config_path}\" , ldmx::test::fires() );\n}"
         )
     list(APPEND src_files ${CMAKE_CURRENT_BINARY_DIR}/test/${config}.cxx)
   endforeach()

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -418,6 +418,7 @@ macro(build_test)
   # setup the test they want to run.
   add_executable(
     run_test ${CMAKE_CURRENT_BINARY_DIR}/external/catch/run_test.cxx
+             ${CMAKE_CURRENT_BINARY_DIR}/external/catch/test_configs.cxx
              ${test_sources})
   target_include_directories(run_test PRIVATE ${CATCH2_INCLUDE_DIR})
   target_link_libraries(run_test PRIVATE Catch2::Interface ${test_dep})

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -361,8 +361,18 @@ macro(setup_test)
   cmake_parse_arguments(setup_test "${options}" "${oneValueArgs}"
                         "${multiValueArgs}" ${ARGN})
 
+  # Assume `.py` files should be run through the process
+  file(GLOB test_configs CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/test/*.py)
+  foreach(config_path ${test_configs})
+    get_filename_component(config ${config_path} NAME)
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/test/${config}.cxx
+        "#include \"catch.hpp\"\n#include \"Framework/Testing.h\"\n\nTEST_CASE(\"Run ${config}\",\"[${PROJECT_NAME}]\") {\nCHECK_THAT( \"${config_path}\" , ldmx::test::fires() );\n}"
+        )
+    list(APPEND src_files ${CMAKE_CURRENT_BINARY_DIR}/test/${config}.cxx)
+  endforeach()
+
   # Find all the test
-  file(GLOB src_files CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/test/*.cxx)
+  file(GLOB src_files CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/test/*.cxx ${CMAKE_CURRENT_BINARY_DIR}/test/*.cxx)
 
   # Add all test to the global list of test sources
   set(test_sources


### PR DESCRIPTION
This addition automatically writes a test case for each test configuration in `test` directories and includes these test cases in the test executable.