### PR TITLE
Rework setup_test and build_test to include test configs

### DIFF
--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -364,19 +364,16 @@ endmacro()
 
 macro(setup_test)
 
-  set(multiValueArgs dependencies)
+  set(oneValueArgs config_dir)
+  set(multiValueArgs dependencies sources configs)
   cmake_parse_arguments(setup_test "${options}" "${oneValueArgs}"
                         "${multiValueArgs}" ${ARGN})
 
   # Find all the test
-  file(GLOB src_files CONFIGURE_DEPENDS
-       ${PROJECT_SOURCE_DIR}/test/[a-zA-Z]*.cxx)
-  file(GLOB py_files CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/test/[a-zA-Z]*.py)
-
-  # If the directory contains python unit test of configurations, copy them over
-  # to the test directory within the build directory.
-  if(py_files)
-    file(COPY ${py_files} DESTINATION ${CMAKE_BINARY_DIR}/test)
+  if(DEFINED setup_test_sources)
+    set(src_files ${setup_test_sources})
+  else()
+    file(GLOB src_files CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/test/[a-zA-Z]*.cxx)
   endif()
 
   # Add all test to the global list of test sources
@@ -394,6 +391,16 @@ macro(setup_test)
   set(test_modules
       ${test_modules} ${module}
       CACHE INTERNAL "test_modules")
+
+  if(DEFINED setup_test_configs)
+    set(new_test_configs ${setup_test_configs})
+  elseif(DEFINED setup_test_config_dir)
+    file(GLOB new_test_configs CONFIGURE ${setup_test_config_dir}/[a-zA-Z]*.py)
+  endif()
+
+  set(test_configs
+      ${test_configs} ${new_test_configs}
+      CACHE INTERNAL "test_configs")
 
 endmacro()
 
@@ -425,11 +432,21 @@ macro(build_test)
   # Install the run_test  executable
   foreach(entry ${test_modules})
     add_test(
-      NAME ${entry}
-      COMMAND run_test "[${entry}]"
-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/test)
+      NAME ${entry} 
+      COMMAND run_test "[${entry}]" 
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${entry}
+      )
   endforeach()
 
+  foreach(config ${test_configs})
+    get_filename_component(c_name ${config} NAME)
+    get_filename_component(c_dir  ${config} DIRECTORY)
+    add_test(
+        NAME "Run_${config}"
+        COMMAND fire ${c_name}
+        WORKING_DIRECTORY ${c_dir}
+        )
+  endforeach()
 endmacro()
 
 macro(clear_cache_variables)
@@ -441,4 +458,5 @@ macro(clear_cache_variables)
   unset(test_dep CACHE)
   unset(test_modules CACHE)
   unset(namespaces CACHE)
+  unset(test_configs CACHE)
 endmacro()


### PR DESCRIPTION
This would allow modules to define a config or a directory of configs to be run through `fire` by `ctest`. This means our Cpp tests are run via Catch2 + ctest and our full python config tests would be run through fire + ctest.