### PR TITLE
Iss17 Updated sanitizer and new compiler settings support

### DIFF
--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -2,6 +2,7 @@ include(CMakeParseArguments)
 include(Sanitizers)
 include(CompilerWarnings)
 
+include(InterProceduralOptimization)
 # Define some colors. These are used to colorize CMake's user output
 if(NOT WIN32)
   string(ASCII 27 esc)
@@ -140,6 +141,7 @@ macro(setup_library)
   target_link_libraries(${library_name} PUBLIC ${setup_library_dependencies})
   enable_sanitizers(${library_name})
   enable_compiler_warnings(${library_name})
+  enable_ipo(${library_name})
 
   # Define an alias. This is used to create the imported target.
   set(alias "${setup_library_module}::${setup_library_module}")

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -1,8 +1,8 @@
 include(CMakeParseArguments)
 include(Sanitizers)
 include(CompilerWarnings)
-
 include(InterProceduralOptimization)
+include(StaticAnalysis)
 # Define some colors. These are used to colorize CMake's user output
 if(NOT WIN32)
   string(ASCII 27 esc)
@@ -142,6 +142,7 @@ macro(setup_library)
   enable_sanitizers(${library_name})
   enable_compiler_warnings(${library_name})
   enable_ipo(${library_name})
+  enable_clang_tidy(${library_name} ${WARNINGS_AS_ERRORS})
 
   # Define an alias. This is used to create the imported target.
   set(alias "${setup_library_module}::${setup_library_module}")

--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -1,5 +1,6 @@
 include(CMakeParseArguments)
 include(Sanitizers)
+include(CompilerWarnings)
 
 # Define some colors. These are used to colorize CMake's user output
 if(NOT WIN32)
@@ -138,6 +139,7 @@ macro(setup_library)
   # Setup the targets to link against
   target_link_libraries(${library_name} PUBLIC ${setup_library_dependencies})
   enable_sanitizers(${library_name})
+  enable_compiler_warnings(${library_name})
 
   # Define an alias. This is used to create the imported target.
   set(alias "${setup_library_module}::${setup_library_module}")

--- a/CompilerWarnings.cmake
+++ b/CompilerWarnings.cmake
@@ -43,7 +43,6 @@ function(
         ${CLANG_WARNINGS}
         -Wmisleading-indentation # warn if indentation implies blocks where blocks do not exist
         -Wduplicated-cond # warn if if / else chain has duplicated conditions
-        -Wduplicated-branches # warn if if / else branches have duplicated code
         -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
         -Wuseless-cast # warn if you perform a cast to the same type
       )
@@ -57,16 +56,26 @@ function(
         -Wno-sign-compare
         # Do we care about this one?
         -Wno-double-promotion # warn if float is implicit promoted to double
-        # SimCore sometimes chokes on this one
-        -Wno-duplicated-branches
       )
       list(APPEND CLANG_WARNINGS
         ${DISABLED_WARNINGS}
         # Clang is being standards-compliant and forbidding conversions in
-        # {}-initialization. Our code isn't currently.
+        # {}-initialization. Our code isn't currently standards-compliant here :)
         -Wno-c++11-narrowing
       )
-      list(APPEND GCC_WARNINGS ${DISABLED_WARNINGS}
+      list(APPEND GCC_WARNINGS
+        ${DISABLED_WARNINGS}
+        # SimCore sometimes chokes on this one :(
+        # -Wduplicated-branches # warn if if / else branches have duplicated code
+        -Wno-duplicated-branches
+        # Clang will warn if you have private member variables that are never
+        # used in the code. You can suppress this with the [[maybe_unused]]
+        # attribute. However, GCC does not provide such a warning and therefore
+        # thinks that the attribute is meaningless.
+        #
+        # See
+        # https://stackoverflow.com/questions/50646334/maybe-unused-on-member-variable-gcc-warns-incorrectly-that-attribute-is
+        -Wno-attributes
       )
     endif()
 

--- a/CompilerWarnings.cmake
+++ b/CompilerWarnings.cmake
@@ -9,11 +9,33 @@ function(
   project_name
   )
   option(WARNINGS_AS_ERRORS "Build LDMX-sw while treating all warnings as errors" OFF)
+  option(PEDANTIC_WARNINGS "Build LDMX-sw with pedantic compiler warnings enabled" OFF)
   option(ADDITIONAL_WARNINGS "Build LDMX-sw with additional compiler warnings enabled" OFF)
 
   if (ADDITIONAL_WARNINGS)
-  if("${CLANG_WARNINGS}" STREQUAL "")
-    set(CLANG_WARNINGS
+    if("${DISABLED_WARNINGS}" STREQUAL "")
+      set(DISABLED_WARNINGS
+        # These are used so much in ldmx-sw that we can't warn on them
+        -Wno-old-style-cast # warn for c-style casts
+        -Wno-unused-parameter
+        -Wno-sign-conversion # warn on sign conversions
+        -Wno-conversion # warn on type conversions that may lose data
+        -Wno-sign-compare
+        # SimCore sometimes chokes on this one
+        -Wno-duplicated-branches
+        # Do we care about this one?
+        -Wno-double-promotion # warn if float is implicit promoted to double
+      )
+    endif()
+    if(PEDANTIC_WARNINGS)
+      set(PEDANTIC_WARNINGS_ENABLED
+        -Wpedantic # warn if non-standard C++ is used
+      )
+    else()
+      set(PEDANTIC_WARNINGS_ENABLED "")
+    endif()
+    if("${CLANG_WARNINGS}" STREQUAL "")
+      set(CLANG_WARNINGS
         -Wall
         -Wextra # reasonable and standard
         -Wshadow # warn the user if a variable declaration shadows one from a parent context
@@ -22,38 +44,25 @@ function(
         -Wcast-align # warn for potential performance problem casts
         -Wunused # warn on anything being unused
         -Woverloaded-virtual # warn if you overload (not override) a virtual function
-        -Wpedantic # warn if non-standard C++ is used
         -Wnull-dereference # warn if a null dereference is detected
         -Wformat=2 # warn on security issues around functions that format output (ie printf)
         -Wimplicit-fallthrough # warn on statements that fallthrough without an explicit annotation
-        # These are used so much in ldmx-sw that we can't warn on them
-        -Wno-old-style-cast # warn for c-style casts
-        -Wno-unused-parameter
-        -Wno-sign-conversion # warn on sign conversions
-        -Wno-conversion # warn on type conversions that may lose data
-        -Wno-sign-compare
-        # Do we care about this one?
-        -Wno-double-promotion # warn if float is implicit promoted to double
-    )
-  endif()
+        ${DISABLED_WARNINGS}
+        ${PEDANTIC_WARNINGS_ENABLED}
+      )
+    endif()
 
-  if("${GCC_WARNINGS}" STREQUAL "")
-    set(GCC_WARNINGS
+    if("${GCC_WARNINGS}" STREQUAL "")
+      set(GCC_WARNINGS
         ${CLANG_WARNINGS}
         -Wmisleading-indentation # warn if indentation implies blocks where blocks do not exist
         -Wduplicated-cond # warn if if / else chain has duplicated conditions
         -Wduplicated-branches # warn if if / else branches have duplicated code
         -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
         -Wuseless-cast # warn if you perform a cast to the same type
-    )
-    set(CLANG_WARNINGS_TMP
-      ${CLANG_WARNINGS}
-    )
-    set(CLANG_WARNINGS
-      ${CLANG_WARNINGS_TMP}
-      -Wno-c++11-narrowing
-    )
-  endif()
+      )
+
+    endif()
 
   endif()
 
@@ -75,7 +84,11 @@ function(
   # use the same warning flags for C
   set(PROJECT_WARNINGS_C "${PROJECT_WARNINGS_CXX}")
 
-
+  # if (NOT
+  #     "${project_name}"
+  #     MATCHES
+  #     "^SimCore"
+  #   )
   target_compile_options(
     ${project_name}
     INTERFACE # C++ warnings
@@ -83,4 +96,7 @@ function(
               # C warnings
               $<$<COMPILE_LANGUAGE:C>:${PROJECT_WARNINGS_C}>
               )
+   # else()
+   #   message(FATAL_ERROR "Not doing warnings for ${project_name}")
+   # endif()
 endfunction()

--- a/CompilerWarnings.cmake
+++ b/CompilerWarnings.cmake
@@ -58,7 +58,7 @@ function(
         # Do we care about this one?
         -Wno-double-promotion # warn if float is implicit promoted to double
         # SimCore sometimes chokes on this one
-        # -Wno-duplicated-branches
+        -Wno-duplicated-branches
       )
       list(APPEND CLANG_WARNINGS
         ${DISABLED_WARNINGS}

--- a/CompilerWarnings.cmake
+++ b/CompilerWarnings.cmake
@@ -13,20 +13,6 @@ function(
   option(ADDITIONAL_WARNINGS "Build LDMX-sw with additional compiler warnings enabled" OFF)
 
   if (ADDITIONAL_WARNINGS)
-    if("${DISABLED_WARNINGS}" STREQUAL "")
-      set(DISABLED_WARNINGS
-        # These are used so much in ldmx-sw that we can't warn on them
-        -Wno-old-style-cast # warn for c-style casts
-        -Wno-unused-parameter
-        -Wno-sign-conversion # warn on sign conversions
-        -Wno-conversion # warn on type conversions that may lose data
-        -Wno-sign-compare
-        # SimCore sometimes chokes on this one
-        -Wno-duplicated-branches
-        # Do we care about this one?
-        -Wno-double-promotion # warn if float is implicit promoted to double
-      )
-    endif()
     if(PEDANTIC_WARNINGS)
       set(PEDANTIC_WARNINGS_ENABLED
         -Wpedantic # warn if non-standard C++ is used
@@ -61,6 +47,28 @@ function(
         -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
         -Wuseless-cast # warn if you perform a cast to the same type
       )
+    if("${DISABLED_WARNINGS}" STREQUAL "")
+      set(DISABLED_WARNINGS
+        # These are used so much in ldmx-sw that we can't warn on them
+        -Wno-old-style-cast # warn for c-style casts
+        -Wno-unused-parameter
+        -Wno-sign-conversion # warn on sign conversions
+        -Wno-conversion # warn on type conversions that may lose data
+        -Wno-sign-compare
+        # Do we care about this one?
+        -Wno-double-promotion # warn if float is implicit promoted to double
+        # SimCore sometimes chokes on this one
+        # -Wno-duplicated-branches
+      )
+      list(APPEND CLANG_WARNINGS
+        ${DISABLED_WARNINGS}
+        # Clang is being standards-compliant and forbidding conversions in
+        # {}-initialization. Our code isn't currently.
+        -Wno-c++11-narrowing
+      )
+      list(APPEND GCC_WARNINGS ${DISABLED_WARNINGS}
+      )
+    endif()
 
     endif()
 
@@ -68,7 +76,6 @@ function(
 
 
   if(WARNINGS_AS_ERRORS)
-    message(TRACE "Warnings are treated as errors")
     list(APPEND CLANG_WARNINGS -Werror)
     list(APPEND GCC_WARNINGS -Werror)
   endif()

--- a/CompilerWarnings.cmake
+++ b/CompilerWarnings.cmake
@@ -1,0 +1,86 @@
+# from here:
+#
+# https://github.com/lefticus/cppbestpractices/blob/master/02-Use_the_Tools_Available.md
+# Originally by Jason Turner/lefticus, released under the "unlicense" license
+# into the public domain
+
+function(
+  enable_compiler_warnings
+  project_name
+  )
+  option(WARNINGS_AS_ERRORS "Build LDMX-sw while treating all warnings as errors" OFF)
+  option(ADDITIONAL_WARNINGS "Build LDMX-sw with additional compiler warnings enabled" OFF)
+
+  if (ADDITIONAL_WARNINGS)
+  if("${CLANG_WARNINGS}" STREQUAL "")
+    set(CLANG_WARNINGS
+        -Wall
+        -Wextra # reasonable and standard
+        -Wshadow # warn the user if a variable declaration shadows one from a parent context
+        -Wnon-virtual-dtor # warn the user if a class with virtual functions has a non-virtual destructor. This helps
+        # catch hard to track down memory errors
+        -Wcast-align # warn for potential performance problem casts
+        -Wunused # warn on anything being unused
+        -Woverloaded-virtual # warn if you overload (not override) a virtual function
+        -Wpedantic # warn if non-standard C++ is used
+        -Wnull-dereference # warn if a null dereference is detected
+        -Wformat=2 # warn on security issues around functions that format output (ie printf)
+        -Wimplicit-fallthrough # warn on statements that fallthrough without an explicit annotation
+        # These are used so much in ldmx-sw that we can't warn on them
+        -Wno-old-style-cast # warn for c-style casts
+        -Wno-unused-parameter
+        -Wno-sign-conversion # warn on sign conversions
+        -Wno-conversion # warn on type conversions that may lose data
+        -Wno-sign-compare
+        # Do we care about this one?
+        -Wno-double-promotion # warn if float is implicit promoted to double
+    )
+  endif()
+
+  if("${GCC_WARNINGS}" STREQUAL "")
+    set(GCC_WARNINGS
+        ${CLANG_WARNINGS}
+        -Wmisleading-indentation # warn if indentation implies blocks where blocks do not exist
+        -Wduplicated-cond # warn if if / else chain has duplicated conditions
+        -Wduplicated-branches # warn if if / else branches have duplicated code
+        -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
+        -Wuseless-cast # warn if you perform a cast to the same type
+    )
+    set(CLANG_WARNINGS_TMP
+      ${CLANG_WARNINGS}
+    )
+    set(CLANG_WARNINGS
+      ${CLANG_WARNINGS_TMP}
+      -Wno-c++11-narrowing
+    )
+  endif()
+
+  endif()
+
+
+  if(WARNINGS_AS_ERRORS)
+    message(TRACE "Warnings are treated as errors")
+    list(APPEND CLANG_WARNINGS -Werror)
+    list(APPEND GCC_WARNINGS -Werror)
+  endif()
+  if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+    set(PROJECT_WARNINGS_CXX ${CLANG_WARNINGS})
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(PROJECT_WARNINGS_CXX ${GCC_WARNINGS})
+  else()
+    message(AUTHOR_WARNING "No compiler warnings set for CXX compiler: '${CMAKE_CXX_COMPILER_ID}'")
+    # TODO support Intel compiler
+  endif()
+
+  # use the same warning flags for C
+  set(PROJECT_WARNINGS_C "${PROJECT_WARNINGS_CXX}")
+
+
+  target_compile_options(
+    ${project_name}
+    INTERFACE # C++ warnings
+              $<$<COMPILE_LANGUAGE:CXX>:${PROJECT_WARNINGS_CXX}>
+              # C warnings
+              $<$<COMPILE_LANGUAGE:C>:${PROJECT_WARNINGS_C}>
+              )
+endfunction()

--- a/InterProceduralOptimization.cmake
+++ b/InterProceduralOptimization.cmake
@@ -1,0 +1,23 @@
+# Based on https://github.com/cpp-best-practices/cmake_template/blob/main/cmake/InterproceduralOptimization.cmake
+# Originally by Jason Turner/lefticus, released under the "unlicense" license
+# into the public domain
+function(enable_ipo library_name)
+  option(ENABLE_LTO "Enable interprocedural/link-time optimization. Drastically slows down link-time if enabled." OFF)
+  # if (NOT "${library_name}"
+  #     MATCHES
+  #     "^SimCore"
+  # )
+
+  if (ENABLE_LTO)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT result OUTPUT output)
+    if(result)
+      set_property(TARGET ${library_name} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+    else()
+      message(SEND_ERROR "IPO is not supported: ${output}")
+    endif()
+  endif()
+  # else()
+  #   message(FATAL_ERROR "Not enabling IPO for ${library_name}")
+  # endif()
+endfunction()

--- a/Sanitizers.cmake
+++ b/Sanitizers.cmake
@@ -34,8 +34,12 @@ function(enable_sanitizers project_name)
     set(SANITIZERS_STRICT "")
 
     option(ENABLE_SANITIZER_ADDRESS "Enable address sanitizer" OFF)
+    option(SANITIZER_ADDRESS_RELAXED "Optionally allow for recover on error for ASAN if ASAN_OPTIONS environment variable is set to halt_on_error=0")
     if(ENABLE_SANITIZER_ADDRESS)
       list(APPEND SANITIZERS "address")
+      if(SANITIZER_ADDRESS_RELAXED)
+        list(APPEND SANITIZERS_RECOVERY "address")
+      endif()
     endif()
 
     option(ENABLE_SANITIZER_LEAK "Enable leak sanitizer" OFF)
@@ -44,8 +48,14 @@ function(enable_sanitizers project_name)
     endif()
 
     option(ENABLE_SANITIZER_UNDEFINED_BEHAVIOR "Enable undefined behavior sanitizer" OFF)
+    option(SANITIZER_UNDEFINED_BEHAVIOR_STRICT
+        "Enable strict enforcement of undefined behavior sanitizers" OFF
+    )
     if(ENABLE_SANITIZER_UNDEFINED_BEHAVIOR)
       list(APPEND SANITIZERS "undefined")
+      if (SANITIZER_UNDEFINED_BEHAVIOR_STRICT)
+        list(APPEND SANITIZERS_STRICT "undefined")
+      endif()
     endif()
 
     option(ENABLE_SANITIZER_THREAD "Enable thread sanitizer" OFF)

--- a/StaticAnalysis.cmake
+++ b/StaticAnalysis.cmake
@@ -1,32 +1,37 @@
 
-function(enable_clang_tidy target WARNINGS_AS_ERRORS)
+macro(enable_clang_tidy target WARNINGS_AS_ERRORS)
 
-  find_program(CLANGTIDY clang-tidy)
-  if(CLANGTIDY)
-    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-    # construct the clang-tidy command line
-    set(CLANG_TIDY_OPTIONS
+
+  option(ENABLE_CLANG_TIDY "Enable running clang-tidy with the build system" OFF)
+
+  if(ENABLE_CLANG_TIDY)
+    find_program(CLANGTIDY clang-tidy)
+    if(CLANGTIDY)
+      set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+      # construct the clang-tidy command line
+      set(CLANG_TIDY_OPTIONS
         ${CLANGTIDY}
         -extra-arg=-Wno-unknown-warning-option
         -extra-arg=-Wno-ignored-optimization-argument
         -extra-arg=-Wno-unused-command-line-argument
         -p)
-    # set standard
-    if(NOT
-       "${CMAKE_CXX_STANDARD}"
-       STREQUAL
-       "")
-     set(CLANG_TIDY_OPTIONS ${CLANG_TIDY_OPTIONS} -extra-arg=-std=c++${CMAKE_CXX_STANDARD})
-    endif()
+      # set standard
+      if(NOT
+          "${CMAKE_CXX_STANDARD}"
+          STREQUAL
+          "")
+        set(CLANG_TIDY_OPTIONS ${CLANG_TIDY_OPTIONS} -extra-arg=-std=c++${CMAKE_CXX_STANDARD})
+      endif()
 
-    # set warnings as errors
-    if(${WARNINGS_AS_ERRORS})
-      list(APPEND CLANG_TIDY_OPTIONS -warnings-as-errors=*)
-    endif()
+      # set warnings as errors
+      if(${WARNINGS_AS_ERRORS})
+        list(APPEND CLANG_TIDY_OPTIONS -warnings-as-errors=*)
+      endif()
 
-    message("Also setting clang-tidy globally")
-    set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_OPTIONS})
-  else()
-    message(${WARNING_MESSAGE} "clang-tidy requested but executable not found")
+      set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_OPTIONS})
+      set_target_properties(${target} PROPERTIES "${CLANGTIDY}" "${CMAKE_CXX_CLANG_TIDY}")
+    else()
+      message(${WARNING_MESSAGE} "clang-tidy requested but executable not found")
+    endif()
   endif()
-endfunction()
+endmacro()

--- a/StaticAnalysis.cmake
+++ b/StaticAnalysis.cmake
@@ -1,0 +1,32 @@
+
+function(enable_clang_tidy target WARNINGS_AS_ERRORS)
+
+  find_program(CLANGTIDY clang-tidy)
+  if(CLANGTIDY)
+    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+    # construct the clang-tidy command line
+    set(CLANG_TIDY_OPTIONS
+        ${CLANGTIDY}
+        -extra-arg=-Wno-unknown-warning-option
+        -extra-arg=-Wno-ignored-optimization-argument
+        -extra-arg=-Wno-unused-command-line-argument
+        -p)
+    # set standard
+    if(NOT
+       "${CMAKE_CXX_STANDARD}"
+       STREQUAL
+       "")
+     set(CLANG_TIDY_OPTIONS ${CLANG_TIDY_OPTIONS} -extra-arg=-std=c++${CMAKE_CXX_STANDARD})
+    endif()
+
+    # set warnings as errors
+    if(${WARNINGS_AS_ERRORS})
+      list(APPEND CLANG_TIDY_OPTIONS -warnings-as-errors=*)
+    endif()
+
+    message("Also setting clang-tidy globally")
+    set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_OPTIONS})
+  else()
+    message(${WARNING_MESSAGE} "clang-tidy requested but executable not found")
+  endif()
+endfunction()


### PR DESCRIPTION
This PR resolves #17 and introduces a couple of new Cmake settings. 
# Sanitizer features
The address sanitizer can now be toggled to not stop on error with the `-DSANITIZER_ADDRESS_RELAXED=ON` flag. To use it, you also need to set the environment variable `ASAN_OPTIONS=halt_on_error=0` 

The undefined behavior sanitizer can be toggled to stop on error with `-DSANITIZER_UNDEFINED_BEHAVIOR_STRICT=ON` 
# Additional compiler warning flags
An extended set of compiler warnings can be enabled from the `CompilerWarnings.cmake` module. If you toggle the `-DADDITIONAL_WARNINGS=ON` flag, This will enable most of the available compiler warnings from both GCC and Clang. Even more warnings can be included by also adding `-DPEDANTIC_WARNINGS=ON`. Finally, warnings can be turned into hard errors with `-DWARNINGS_AS_ERRORS=ON`. 

## Disabled by default warnings
Currently, there are a couple of warnings that I've set to be excluded usually because they would trigger way too often in ldmx-sw. Some of these would be useful though so they are worth thinking about.

- ` -Wduplicated-branches # warn if if / else branches have duplicated code` This one makes GCC choke when trying to compile SimCore. I don't know why
- `-Wsign-conversion` 
- `-Wconversion`
-  `-Wc++11-narrowing` Clang by default turns narrowing conversions inside of {}-initializiation into errors (which is what standard C++ is supposed to do). 
- `-Wsign-compare`
- `-Wdouble-promotion`  warn if float is implicit promoted to double
- `-Wold-style-cast`  warn for c-style casts
- `-Wunused-parameter` (this one produces a hilarious number of warnings in ldmx-sw)

When I was experimenting with these in SimCore, it was relatively straight-forward to handle even the disabled warnings if you focus on just the module you are working on. The problem with these warnings comes more when you run it on ldmx-sw as a whole. 

Of these, I would consider all but the last three to in principle be useful. 

# Static analysis 
The de-facto standard tool for running compiler based static analysis on C++ code is clang-tidy. It is a relative to clang-format which we already make use of. The `StaticAnalysis.cmake` module adds support for running clang-tidy tool when compiling. Since clang-tidy relies on the compiler, it needs to know how to build our code. To solve this, when `-DENABLE_CLANG_TIDY` is set to `ON`, cmake will produce a  JSON file called `compile_commands.json` that contains all the compiler flags. 

In addition to running clang-tidy as part of the regular build, you can run it on individual source files. All you need to do is tell it where to find the `compile_commands.json` flag. 

```shell
# Assuming you have a container that includes clang-tidy 
# -p dir -> directory with the compile_commands.json file
ldmx clang-tidy -p build/ MyModule/src/MyModule/MyFile.cxx 
# Optionally, add a filter to also include analysis of relevant header files 
# This would include anything from the other header files in the module
ldmx clang-tidy -p build/ MyModule/src/MyModule/MyFile.cxx --header-filter="MyModule/*"  
# This would include anything from within ldmx-sw
ldmx clang-tidy -p build/ MyModule/src/MyModule/MyFile.cxx --header-filter=".*"  
```

By default, something equivalent to the following checks are enabled 
`'clang-diagnostic-*,clang-analyzer-*'` 

These are the checks that are most likely to catch regular bugs. There are a whole bunch of other ones out there (e.g. modernize, readability, google's). If there is something we decide together that we want to have as a rule in ldmx-sw this can be added by including a .clang-tidy file in ldmx-sw. 

To test this, I've been using the .clang-tidy flag that the Geant4 collaboration uses

# Link time/Interprocedural optimization
Lastly, I've added a module that enables link time optimization (LTO). I'm not actually including it for the optimization possibilities. Those are worth investigating but without measurements there's no way to know if it would produce a performance improvement. However, LTO builds enable some really powerful static analysis opportunities for the compiler. In particular, it allows the compiler to diagnose some of the most insidious types of bugs in C/C++, ODR-violations. 

LTO is enabled with the `-DENABLE_LTO=ON` flag