### PR TITLE
refactor test setup and build

### DIFF
--- a/BuildMacros.cmake
+++ b/BuildMacros.cmake
@@ -381,7 +381,7 @@ macro(build_test)
     add_test(
         NAME "Run_${module}_${config_name}"
         COMMAND fire ${config_filepath}
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${entry}/test
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${module}/test
         )
   endforeach()
 endmacro()


### PR DESCRIPTION
- allow users to specify config files to run through fire during ctest.
  These configs are run within the module's testing directory in the
  build directory `(build/<module>/test`) and are just checked to not have
failed

- the Catch test is run for each module that appends any sources to it
  and only tests with that module's name as a tag are run. For each
  module, the catch test is also run from within is `build/<module>/test`
  directory and all the files from the source test directory are
  symlinked into this directory for reading purposes if needed.
